### PR TITLE
feat: add aws_key_pair resource

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -44,7 +44,7 @@ module "module_example" {
   app_description   = "Example app to demo the module with"
   aws_ami           = "ami-0e040c48614ad1327"
   aws_instance_type = "t2.micro"
-  ssh_key_name      = "id_dev"
+  ec2_public_key    = var.ec2_public_key
   instance_user_data = templatefile(local.init_ec2_template_path, {
     bucket                     = aws_s3_bucket.example_bucket.bucket
     docker_compose_s3_key_path = local.docker_compose_s3_key_path

--- a/example/variables.tf
+++ b/example/variables.tf
@@ -8,3 +8,10 @@ variable "cloudflare_zone_id" {
   type        = string
   description = "The Cloudflare zone ID"
 }
+
+variable "ec2_public_key" {
+  description = "The public key to use for the EC2 instance"
+  type        = string
+  nullable    = false
+  sensitive   = true
+}

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "aws_instance" "app_server" {
   instance_type   = var.aws_instance_type
   subnet_id       = aws_subnet.public_subnet.id
   security_groups = [aws_security_group.sg.id]
-  key_name        = var.ssh_key_name
+  key_name        = aws_key_pair.ec2_key_pair.key_name
 
   iam_instance_profile = aws_iam_instance_profile.bucket_instance_profile.id
 
@@ -37,4 +37,9 @@ resource "aws_instance" "app_server" {
   root_block_device {
     volume_type = "gp3"
   }
+}
+
+resource "aws_key_pair" "ec2_key_pair" {
+  key_name   = "${local.resource_prefix}-tf-key"
+  public_key = var.ec2_public_key
 }

--- a/variables.tf
+++ b/variables.tf
@@ -40,9 +40,10 @@ variable "aws_ami" {
   nullable    = false
 }
 
-variable "ssh_key_name" {
-  description = "The name of the SSH key that will be used to access the provisioned instance"
+variable "ec2_public_key" {
+  description = "The public key to use for the EC2 instance"
   type        = string
+  sensitive   = true
 }
 
 variable "instance_user_data" {


### PR DESCRIPTION
Adds support for creating the EC2 Key Pair with a given public key rather than quietly requiring it to already exist outside the scope of the module.